### PR TITLE
Removes query_cache_size parameter from the config

### DIFF
--- a/low-memory.cnf
+++ b/low-memory.cnf
@@ -24,7 +24,6 @@ skip-name-resolve
 #### http://www.tocker.ca/2014/03/10/configuring-mysql-to-use-minimal-memory.html
 innodb_buffer_pool_size=5M
 innodb_log_buffer_size=256K
-query_cache_size=0
 max_connections=10
 key_buffer_size=8
 thread_cache_size=0


### PR DESCRIPTION
**query_cache size** parameter is removed as of MySQL 8.0.3, and has been deprecated since MySQL 5.7.20. I also tested the memory footprint on latest MySQL 5.6 version, and it is the same as with this parameter. I would also advise re-building all existing 8.0.x images with the new configuration. 

fixes #1 